### PR TITLE
Handle empty `__all__`s

### DIFF
--- a/sort_all.py
+++ b/sort_all.py
@@ -124,6 +124,9 @@ def _fix_src(contents_text: str, fname: str) -> str:
     idx = 0
 
     for elts in visitor._elts:
+        if not elts:
+            continue
+
         start = Offset(elts[0].lineno, elts[0].col_offset)
         chunk, idx = consume(tokens, idx, start)
         chunks.append(chunk)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -290,6 +290,7 @@ def test_sort_aug_assign_real() -> None:
 
     assert expected == sort_all._fix_src(txt, "<input>")
 
+
 def test_sort_empty_tuple() -> None:
     txt = dedent(
         """\

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -289,3 +289,42 @@ def test_sort_aug_assign_real() -> None:
     )
 
     assert expected == sort_all._fix_src(txt, "<input>")
+
+def test_sort_empty_tuple() -> None:
+    txt = dedent(
+        """\
+        from mod import name1, name2
+
+        __all__ = ()
+    """
+    )
+
+    expected = dedent(
+        """\
+        from mod import name1, name2
+
+        __all__ = ()
+    """
+    )
+
+    assert expected == sort_all._fix_src(txt, "<input>")
+
+
+def test_sort_empty_list() -> None:
+    txt = dedent(
+        """\
+        from mod import name1, name2
+
+        __all__ = []
+    """
+    )
+
+    expected = dedent(
+        """\
+        from mod import name1, name2
+
+        __all__ = []
+    """
+    )
+
+    assert expected == sort_all._fix_src(txt, "<input>")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This fixes an error which is raised when an empty `__all__` is found, like the following example:


```py
# test.py
import typing

__all__ = ()

```

which would lead to an error like the following when the latest sort-all v1.1.0 was run over it on linux or windows

```
Traceback (most recent call last):
  File "/mnt/c/Users/Lucina/PycharmProjects/tanjun/venv-deb/bin/sort-all", line 8, in <module>
    sys.exit(main())
  File "/mnt/c/Users/Lucina/PycharmProjects/tanjun/venv-deb/lib/python3.10/site-packages/sort_all.py", line 188, in main
    retv |= fix_file(filename)
  File "/mnt/c/Users/Lucina/PycharmProjects/tanjun/venv-deb/lib/python3.10/site-packages/sort_all.py", line 171, in fix_file
    new_content = _fix_src(contents_text, filename)
  File "/mnt/c/Users/Lucina/PycharmProjects/tanjun/venv-deb/lib/python3.10/site-packages/sort_all.py", line 127, in _fix_src
    start = Offset(elts[0].lineno, elts[0].col_offset)
IndexError: list index out of range
```

## Are there changes in behavior for the user?

Won't error on an empty `__all__` anymore.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [N/A] Documentation reflects the changes
- [N/A] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
