### PR TITLE
Add --check, --no-error-on-fix flags

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,11 @@ repos:
   hooks:
   - id: autopep8
 - repo: https://github.com/PyCQA/isort
-  rev: '5.10.1'
+  rev: '5.13.2'
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
-  rev: '22.1.0'
+  rev: '22.3.0'
   hooks:
   - id: black
     language_version: python3 # Should be a command that runs python3.6+


### PR DESCRIPTION
Fix pre-commit versions

<!-- Thank you for your contribution! -->

## What do these changes do?

Adds flow control to enable dry-run and disable errors on fix

## Are there changes in behavior for the user?

User gets control over linting flow using flags

## Related issue number

Fixes #61

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
