### PR TITLE
add wildcard support

### DIFF
--- a/sort_all.py
+++ b/sort_all.py
@@ -3,6 +3,8 @@ import ast
 import sys
 import warnings
 from collections.abc import Sequence
+from glob import glob
+from itertools import chain
 from operator import attrgetter
 from typing import Optional
 
@@ -209,7 +211,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     args = parser.parse_args(argv)
 
     retv = 0
-    for filename in args.filenames:
+    for filename in chain.from_iterable(*map(glob, args.filenames)):
         if not filename.endswith((".py", ".pyx", ".pyi", ".pyd")):
             continue
         retv |= fix_file(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

These Changes to sort-all allow effective recursions through multiple directories via the use of wildcards 

example:
```
sort-all src/* 
```
Would sort all files in src/* that end with .py, .pxd, .pyx, .pyi files allowing for lazier sorting to take place.

## Are there changes in behavior for the user?

There is now a way to lazily sort multiple modules with the use of __sort-all__

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
